### PR TITLE
Addressed security issues found in vSphere provider gosec scan (LMSS-1190)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/hashicorp/terraform-provider-vsphere
 
 go 1.16
-replace github.com/vmware/govmomi => ../govmomi
 require (
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.37.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,7 @@
 module github.com/hashicorp/terraform-provider-vsphere
 
 go 1.16
-
+replace github.com/vmware/govmomi => ../govmomi
 require (
 	github.com/apparentlymart/go-cidr v1.1.0 // indirect
 	github.com/aws/aws-sdk-go v1.37.0 // indirect

--- a/vsphere/config.go
+++ b/vsphere/config.go
@@ -63,11 +63,11 @@ type Client struct {
 // Read call to determine if tags are supported on this connection, and if they
 // are, read them from the object and save them in the resource:
 //
-//   if tm, _ := meta.(*VSphereClient).TagsManager(); tm != nil {
-//     if err := readTagsForResource(restClient, obj, d); err != nil {
-//       return err
-//     }
-//   }
+//	if tm, _ := meta.(*VSphereClient).TagsManager(); tm != nil {
+//	  if err := readTagsForResource(restClient, obj, d); err != nil {
+//	    return err
+//	  }
+//	}
 func (c *Client) TagsManager() (*tags.Manager, error) {
 	if err := viapi.ValidateVirtualCenter(c.vimClient); err != nil {
 		return nil, err
@@ -353,6 +353,7 @@ func (c *Config) SaveVimClient(client *govmomi.Client) error {
 		return err
 	}
 
+	p = filepath.Clean(p)
 	f, err := os.OpenFile(p, os.O_CREATE|os.O_WRONLY, 0600)
 	if err != nil {
 		return err
@@ -391,6 +392,7 @@ func (c *Config) restoreVimClient(client *vim25.Client) (bool, error) {
 		return false, err
 	}
 	log.Printf("[DEBUG] Attempting to locate SOAP client session data in %q", p)
+	p = filepath.Clean(p)
 	f, err := os.Open(p)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -524,6 +526,7 @@ func restSessionValid(client *rest.Client) bool {
 	return true
 }
 func readRestSession(path string) (string, error) {
+	path = filepath.Clean(path)
 	f, err := os.Open(path)
 	if err != nil {
 		if os.IsNotExist(err) {

--- a/vsphere/data_source_vsphere_host_thumbprint.go
+++ b/vsphere/data_source_vsphere_host_thumbprint.go
@@ -2,7 +2,7 @@ package vsphere
 
 import (
 	"bytes"
-	"crypto/sha1"
+	"crypto/sha256"
 	"crypto/tls"
 	"fmt"
 
@@ -34,14 +34,14 @@ func dataSourceVSphereHostThumbprint() *schema.Resource {
 }
 
 func dataSourceVSphereHostThumbprintRead(d *schema.ResourceData, _ interface{}) error {
-	config := &tls.Config{}
+	config := &tls.Config{MinVersion: tls.VersionTLS12}
 	config.InsecureSkipVerify = d.Get("insecure").(bool)
 	conn, err := tls.Dial("tcp", d.Get("address").(string)+":"+d.Get("port").(string), config)
 	if err != nil {
 		return err
 	}
 	cert := conn.ConnectionState().PeerCertificates[0]
-	fingerprint := sha1.Sum(cert.Raw)
+	fingerprint := sha256.Sum224(cert.Raw)
 
 	var buf bytes.Buffer
 	for i, f := range fingerprint {

--- a/vsphere/host_data_store_system_helper.go
+++ b/vsphere/host_data_store_system_helper.go
@@ -35,10 +35,9 @@ func availableScsiDisk(dss *object.HostDatastoreSystem, name string) (*types.Hos
 	}
 
 	var disk *types.HostScsiDisk
-	for _, d := range disks {
+	for di, d := range disks {
 		if d.CanonicalName == name {
-			d := d
-			disk = &d
+			disk = &(disks[di])
 			break
 		}
 	}
@@ -64,10 +63,9 @@ func diskSpecForCreate(dss *object.HostDatastoreSystem, name string) (*types.Vmf
 		return nil, fmt.Errorf("could not get disk creation options for %q: %s", name, err)
 	}
 	var option *types.VmfsDatastoreOption
-	for _, o := range options {
-		if _, ok := o.Info.(*types.VmfsDatastoreAllExtentOption); ok {
-			o := o
-			option = &o
+	for oi, o := range options {
+		if oi, ok := o.Info.(*types.VmfsDatastoreAllExtentOption); ok {
+			option = &(options[oi])
 			break
 		}
 	}
@@ -99,10 +97,9 @@ func diskSpecForExtend(dss *object.HostDatastoreSystem, ds *object.Datastore, na
 		return nil, fmt.Errorf("could not get disk extension options for %q: %s", name, err)
 	}
 	var option *types.VmfsDatastoreOption
-	for _, o := range options {
-		if _, ok := o.Info.(*types.VmfsDatastoreAllExtentOption); ok {
-			o := o
-			option = &o
+	for oi, o := range options {
+		if oi, ok := o.Info.(*types.VmfsDatastoreAllExtentOption); ok {
+			option = &(options[oi])
 			break
 		}
 	}

--- a/vsphere/host_data_store_system_helper.go
+++ b/vsphere/host_data_store_system_helper.go
@@ -64,7 +64,7 @@ func diskSpecForCreate(dss *object.HostDatastoreSystem, name string) (*types.Vmf
 	}
 	var option *types.VmfsDatastoreOption
 	for oi, o := range options {
-		if oi, ok := o.Info.(*types.VmfsDatastoreAllExtentOption); ok {
+		if _, ok := o.Info.(*types.VmfsDatastoreAllExtentOption); ok {
 			option = &(options[oi])
 			break
 		}
@@ -98,7 +98,7 @@ func diskSpecForExtend(dss *object.HostDatastoreSystem, ds *object.Datastore, na
 	}
 	var option *types.VmfsDatastoreOption
 	for oi, o := range options {
-		if oi, ok := o.Info.(*types.VmfsDatastoreAllExtentOption); ok {
+		if _, ok := o.Info.(*types.VmfsDatastoreAllExtentOption); ok {
 			option = &(options[oi])
 			break
 		}

--- a/vsphere/host_data_store_system_helper.go
+++ b/vsphere/host_data_store_system_helper.go
@@ -37,6 +37,7 @@ func availableScsiDisk(dss *object.HostDatastoreSystem, name string) (*types.Hos
 	var disk *types.HostScsiDisk
 	for _, d := range disks {
 		if d.CanonicalName == name {
+			d := d
 			disk = &d
 			break
 		}
@@ -65,6 +66,7 @@ func diskSpecForCreate(dss *object.HostDatastoreSystem, name string) (*types.Vmf
 	var option *types.VmfsDatastoreOption
 	for _, o := range options {
 		if _, ok := o.Info.(*types.VmfsDatastoreAllExtentOption); ok {
+			o := o
 			option = &o
 			break
 		}
@@ -99,6 +101,7 @@ func diskSpecForExtend(dss *object.HostDatastoreSystem, ds *object.Datastore, na
 	var option *types.VmfsDatastoreOption
 	for _, o := range options {
 		if _, ok := o.Info.(*types.VmfsDatastoreAllExtentOption); ok {
+			o := o
 			option = &o
 			break
 		}

--- a/vsphere/internal/helper/contentlibrary/content_library_helper.go
+++ b/vsphere/internal/helper/contentlibrary/content_library_helper.go
@@ -321,6 +321,7 @@ func (uploadSession libraryUploadSession) uploadLocalFile(file string) error {
 }
 
 func openLocalFile(file string) (*io.Reader, *int64, error) {
+	file = filepath.Clean(file)
 	openFile, err := os.Open(file)
 	if err != nil {
 		return nil, nil, err
@@ -351,9 +352,14 @@ func (uploadSession libraryUploadSession) uploadOvaDisksFromLocal(ovaFilePath st
 }
 
 func (uploadSession libraryUploadSession) uploadOvaDisksFromURL(ovfFilePath string, diskName string, size int64) error {
-	resp, err := http.Get(ovfFilePath)
+	//	resp, err := http.Get(ovfFilePath)
+	req, err := http.NewRequest(http.MethodGet, ovfFilePath, nil)
 	if err != nil {
 		return err
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("error sending request: %w", err)
 	}
 	if resp.StatusCode == http.StatusOK {
 		err = uploadSession.findAndUploadDiskFromOva(resp.Body, diskName, size)

--- a/vsphere/internal/helper/ovfdeploy/ovf_helper.go
+++ b/vsphere/internal/helper/ovfdeploy/ovf_helper.go
@@ -11,6 +11,7 @@ import (
 	"log"
 	"net/http"
 	"os"
+	"path/filepath"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -190,6 +191,7 @@ func uploadDisksFromLocal(filePath string, ovfFileItem types.OvfFileItem, device
 	}
 	vmdkFilePath := absoluteFilePath + ovfFileItem.Path
 	log.Print(" [DEBUG] Absolute vmdk path: " + vmdkFilePath)
+	vmdkFilePath = filepath.Clean(vmdkFilePath)
 	file, err := os.Open(vmdkFilePath)
 	if err != nil {
 		return err
@@ -227,6 +229,7 @@ func uploadDisksFromURL(filePath string, ovfFileItem types.OvfFileItem, deviceOb
 
 func uploadOvaDisksFromLocal(filePath string, ovfFileItem types.OvfFileItem, deviceObj types.HttpNfcLeaseDeviceUrl, currBytesRead *int64) error {
 	diskName := ovfFileItem.Path
+	filePath = filepath.Clean(filePath)
 	ovaFile, err := os.Open(filePath)
 	if err != nil {
 		return err
@@ -265,6 +268,7 @@ func GetOvfDescriptor(filePath string, deployOva bool, fromLocal bool, allowUnve
 	ovfDescriptor := ""
 	if !deployOva {
 		if fromLocal {
+			filePath = filepath.Clean(filePath)
 			fileBuffer, err := ioutil.ReadFile(filePath)
 			if err != nil {
 				return "", err
@@ -290,6 +294,7 @@ func GetOvfDescriptor(filePath string, deployOva bool, fromLocal bool, allowUnve
 		}
 	} else {
 		if fromLocal {
+			filePath = filepath.Clean(filePath)
 			ovaFile, err := os.Open(filePath)
 			if err != nil {
 				return "", err


### PR DESCRIPTION
### Description

<!--- Please leave a helpful description of the pull request here. --->
Addressed security issues found in vSphere provider gosec scan
(https://jira-pro.it.hpe.com:8443/browse/LMSS-1190)




<html xmlns:v="urn:schemas-microsoft-com:vml"
xmlns:o="urn:schemas-microsoft-com:office:office"
xmlns:x="urn:schemas-microsoft-com:office:excel"
xmlns="http://www.w3.org/TR/REC-html40">

<head>

<meta name=ProgId content=Excel.Sheet>
<meta name=Generator content="Microsoft Excel 15">
<link id=Main-File rel=Main-File
href="file:///C:/Users/bhardaji/AppData/Local/Temp/msohtmlclip1/01/clip.htm">
<link rel=File-List
href="file:///C:/Users/bhardaji/AppData/Local/Temp/msohtmlclip1/01/clip_filelist.xml">
<style>
<!--table
	{mso-displayed-decimal-separator:"\.";
	mso-displayed-thousand-separator:"\,";}
@page
	{margin:.75in .7in .75in .7in;
	mso-header-margin:.3in;
	mso-footer-margin:.3in;}
tr
	{mso-height-source:auto;}
col
	{mso-width-source:auto;}
br
	{mso-data-placement:same-cell;}
td
	{padding-top:1px;
	padding-right:1px;
	padding-left:1px;
	mso-ignore:padding;
	color:black;
	font-size:11.0pt;
	font-weight:400;
	font-style:normal;
	text-decoration:none;
	font-family:Calibri, sans-serif;
	mso-font-charset:0;
	mso-number-format:General;
	text-align:general;
	vertical-align:bottom;
	border:none;
	mso-background-source:auto;
	mso-pattern:auto;
	mso-protection:locked visible;
	white-space:nowrap;
	mso-rotate:0;}
.xl65
	{mso-number-format:"\@";
	border:.5pt solid windowtext;
	white-space:normal;}
.xl66
	{mso-number-format:"\@";
	vertical-align:middle;
	border:.5pt solid windowtext;
	white-space:normal;}
.xl67
	{font-size:10.0pt;
	font-family:"Arial Unicode MS";
	mso-generic-font-family:auto;
	mso-font-charset:0;
	mso-number-format:"\@";
	border:.5pt solid windowtext;
	white-space:normal;}
.xl68
	{border:.5pt solid windowtext;}
.xl69
	{mso-number-format:"\@";
	border-top:.5pt solid windowtext;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;
	white-space:normal;}
.xl70
	{mso-number-format:"\@";
	border-top:none;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;
	white-space:normal;}
.xl71
	{border-top:none;
	border-right:none;
	border-bottom:none;
	border-left:.5pt solid windowtext;}
.xl72
	{border-top:none;
	border-right:none;
	border-bottom:.5pt solid windowtext;
	border-left:.5pt solid windowtext;}
-->
</style>
</head>

<body link="#0563C1" vlink="#954F72">


Provider   Name | Rule ID | Issue details | location of   reported issue | Outcome | Reference
-- | -- | -- | -- | -- | --
VMWare   Vphere (https://github.com/ranga-hpe/terraform-provider-vsphere) | G401 (CWE-326) | Description:  Detect the usage of DES, RC4, MD5 or   SHA1 |   |   |  
  |   | Reported   warning message: Use of weak cryptographic primitive | Line no.44 in file vsphere/data_source_vsphere_host_thumbprint.go | tested   with SHA224 | https://pkg.go.dev/crypto/sha256
  | G402 (CWE-295) | Description:   Look for bad TLS connection settings |   |   |  
  |   | Reported   warning message: TLS MinVersion too low | 1.   Line no. in file vsphere/data_source_vsphere_host_thumbprint.go | tested   with MinVersion: tls.VersionTLS12 | https://github.com/redis/go-redis/issues/1553
  |   | Reported   warning message: TLS InsecureSkipVerify set true | 2.   Line no.383 in file vsphere/internal/helper/ovfdeploy/ovf_helper.go | self-signed   cert being used, will be handled outside of this PR |  
  | G505 (CWE-327) | Description:   Import blocklist: crypto/sha1 |   |   |  
  |   | Reported   warning message: weak cryptographic primitive | Line no.5 in file vsphere/data_source_vsphere_host_thumbprint.go | tested   with SHA224 | https://pkg.go.dev/crypto/sha256
  | G304 (CWE-22) | Description:   File path provided as taint input |   |   |  
  |   | Reported   warning message: Potential file inclusion via variable | 1.   Lines no.293, 268, 230 and 193 in file   vsphere/internal/helper/ovfdeploy/ovf_helper.go | tested   with var = filepath.Clean(var) | https://stackoverflow.com/questions/70281883/golang-untaint-url-variable-to-fix-gosec-warning-g107
  |   |   | 2.   Line no.324 in file   vsphere/internal/helper/contentlibrary/content_library_helper.go | tested   with var = filepath.Clean(var) | https://stackoverflow.com/questions/70281883/golang-untaint-url-variable-to-fix-gosec-warning-g107
  |   |   | 3.   Line no.527, 394 and 356 in file vsphere/config.go | tested   with var = filepath.Clean(var) | https://stackoverflow.com/questions/70281883/golang-untaint-url-variable-to-fix-gosec-warning-g107
  | G107 (CWE-88) | Description:   Url provided to HTTP request as taint input |   |   |  
  |   | Reported warning   message: Potential HTTP request made with variable url | Line no.354 in file vsphere/internal/helper/contentlibrary/content_library_helper.go | tested   with http.NewRequest | https://securego.io/docs/rules/g107.html
  | G601 (CWE-118) | Description: Implicit   memory aliasing of items from a range statement |   |   |  
  |   | Reported warning   message: Implicit memory aliasing in for loop. | Lines no.40, 68 and 102 in file vsphere/host_data_store_system_helper.go | tested   with var:=var in the for loop | https://stackoverflow.com/questions/62446118/implicit-memory-aliasing-in-for-loop



</body>

</html>

